### PR TITLE
fix: move back to single line input via textbox to avoid newlines

### DIFF
--- a/protein_calculator/protein_calculator.xml
+++ b/protein_calculator/protein_calculator.xml
@@ -2,7 +2,7 @@
     <description>by the VIB Protein Core</description>
     <macros>
         <token name="@TOOL_VERSION@">1.1.0</token>
-        <token name="@VERSION_SUFFIX@">0</token>
+        <token name="@VERSION_SUFFIX@">1</token>
     </macros>
     <edam_topics>
         <edam_topic>topic_0123</edam_topic>

--- a/protein_calculator/protein_calculator.xml
+++ b/protein_calculator/protein_calculator.xml
@@ -57,7 +57,7 @@
             </when>
             <when value="textbox">
                 <param argument="--name" type="text" label="Protein name" help="Name of the protein" optional="false" />
-                <param argument="--sequence" type="text" area="true" label="Protein sequence" help="Sequence to be processed. Protein sequence should have a minimum length of 10 residues. " optional="false"/>
+                <param argument="--sequence" type="text" area="false" label="Protein sequence" help="Sequence to be processed. Protein sequence should have a minimum length of 10 residues. " optional="false" />
             </when>
         </conditional>
     </inputs>


### PR DESCRIPTION
Fix bug when newlines or 'Enter's are included in the pasted sequence. Bumped wrapper version. 
